### PR TITLE
feat: real multi-backend connection pooling (fix #140)

### DIFF
--- a/migrations_postgres/2024-07-05-093153_users/down.sql
+++ b/migrations_postgres/2024-07-05-093153_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE users;

--- a/migrations_postgres/2024-07-05-093153_users/up.sql
+++ b/migrations_postgres/2024-07-05-093153_users/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+CREATE TABLE users (
+        id SERIAL PRIMARY KEY,
+        username TEXT NOT NULL,
+        password TEXT NOT NULL,
+        email TEXT NOT NULL,
+        created_at TIMESTAMP NOT NULL,
+        modified_at TIMESTAMP NOT NULL,
+	reset_token TEXT,
+	CONSTRAINT UC_Users UNIQUE (username,email)
+      );

--- a/migrations_postgres/2024-07-12-051207_repositories/down.sql
+++ b/migrations_postgres/2024-07-12-051207_repositories/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE repositories

--- a/migrations_postgres/2024-07-12-051207_repositories/up.sql
+++ b/migrations_postgres/2024-07-12-051207_repositories/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE repositories (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  platforms TEXT,
+  plugins TEXT,
+  UNIQUE (name)
+);

--- a/migrations_postgres/2024-07-12-080252_users_repositories/down.sql
+++ b/migrations_postgres/2024-07-12-080252_users_repositories/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE users_repositories

--- a/migrations_postgres/2024-07-12-080252_users_repositories/up.sql
+++ b/migrations_postgres/2024-07-12-080252_users_repositories/up.sql
@@ -1,0 +1,12 @@
+-- Your SQL goes here
+-- Text + CHECK rather than a native Postgres enum type, to keep the Rust
+-- side (models.rs's Permission ToSql/FromSql) identical to the SQLite path.
+-- Includes 'pending' (used by src/diesel.rs's join_update_server via
+-- Permission::Pending), which the original MySQL migration's
+-- ENUM("read", "write") is missing.
+CREATE TABLE users_repositories (
+  user_id INTEGER NOT NULL,
+  repository_name VARCHAR(255) NOT NULL,
+  permission TEXT NOT NULL CHECK (permission IN ('read', 'write', 'pending')),
+  PRIMARY KEY(user_id, repository_name)
+);

--- a/migrations_postgres/2025-09-23-105736-0000_plugins/down.sql
+++ b/migrations_postgres/2025-09-23-105736-0000_plugins/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE plugins

--- a/migrations_postgres/2025-09-23-105736-0000_plugins/up.sql
+++ b/migrations_postgres/2025-09-23-105736-0000_plugins/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE TABLE plugins (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  version VARCHAR(255) NOT NULL
+);

--- a/migrations_sqlite/2024-07-05-093153_users/down.sql
+++ b/migrations_sqlite/2024-07-05-093153_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE users;

--- a/migrations_sqlite/2024-07-05-093153_users/up.sql
+++ b/migrations_sqlite/2024-07-05-093153_users/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL,
+        password TEXT NOT NULL,
+        email TEXT NOT NULL,
+        created_at TIMESTAMP NOT NULL,
+        modified_at TIMESTAMP NOT NULL,
+	reset_token TEXT,
+	CONSTRAINT UC_Users UNIQUE (username,email)
+      );

--- a/migrations_sqlite/2024-07-12-051207_repositories/down.sql
+++ b/migrations_sqlite/2024-07-12-051207_repositories/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE repositories

--- a/migrations_sqlite/2024-07-12-051207_repositories/up.sql
+++ b/migrations_sqlite/2024-07-12-051207_repositories/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE repositories (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  platforms TEXT,
+  plugins TEXT,
+  UNIQUE (name)
+);

--- a/migrations_sqlite/2024-07-12-080252_users_repositories/down.sql
+++ b/migrations_sqlite/2024-07-12-080252_users_repositories/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE users_repositories

--- a/migrations_sqlite/2024-07-12-080252_users_repositories/up.sql
+++ b/migrations_sqlite/2024-07-12-080252_users_repositories/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+-- SQLite has no native ENUM type; store the same lowercase strings as the
+-- MySQL ENUM column would, constrained the same way. Includes 'pending'
+-- (used by src/diesel.rs's join_update_server via Permission::Pending),
+-- which the original MySQL migration's ENUM("read", "write") is missing.
+CREATE TABLE users_repositories (
+  user_id INTEGER NOT NULL,
+  repository_name VARCHAR(255) NOT NULL,
+  permission TEXT NOT NULL CHECK (permission IN ('read', 'write', 'pending')),
+  PRIMARY KEY(user_id, repository_name)
+);

--- a/migrations_sqlite/2025-09-23-105736-0000_plugins/down.sql
+++ b/migrations_sqlite/2025-09-23-105736-0000_plugins/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE plugins

--- a/migrations_sqlite/2025-09-23-105736-0000_plugins/up.sql
+++ b/migrations_sqlite/2025-09-23-105736-0000_plugins/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE TABLE plugins (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name VARCHAR(255) NOT NULL,
+  version VARCHAR(255) NOT NULL
+);

--- a/src/diesel.rs
+++ b/src/diesel.rs
@@ -32,8 +32,37 @@ use std::{
 };
 use url::Url;
 
-pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
-pub static POOL: OnceLock<Mutex<Option<Pool<AsyncMysqlConnection>>>> = OnceLock::new();
+pub const MYSQL_MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+// SQLite/PostgreSQL don't accept MySQL's AUTO_INCREMENT/native ENUM syntax,
+// so each backend gets its own portable migration set rather than sharing
+// MYSQL_MIGRATIONS. See migrations_sqlite/, migrations_postgres/, and
+// models.rs's per-backend ToSql/FromSql impls for Permission.
+pub const SQLITE_MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations_sqlite");
+pub const POSTGRES_MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations_postgres");
+
+// Interim multi-backend pool: diesel_async's upstream `MultiConnection` trait
+// (which would let a single Pool<C> cover all three backends) isn't released
+// yet, so this enum + the with_conn! macro below stand in for it. Every
+// function using with_conn! runs the *same* Diesel DSL body against whichever
+// concrete connection type the pool holds — the query code itself doesn't
+// change per backend, only which connection type executes it.
+pub enum DbPool {
+    Mysql(Pool<AsyncMysqlConnection>),
+    Pg(Pool<AsyncPgConnection>),
+    Sqlite(Pool<SyncConnectionWrapper<SqliteConnection>>),
+}
+
+impl Clone for DbPool {
+    fn clone(&self) -> Self {
+        match self {
+            DbPool::Mysql(p) => DbPool::Mysql(p.clone()),
+            DbPool::Pg(p) => DbPool::Pg(p.clone()),
+            DbPool::Sqlite(p) => DbPool::Sqlite(p.clone()),
+        }
+    }
+}
+
+pub static POOL: OnceLock<Mutex<Option<DbPool>>> = OnceLock::new();
 
 pub enum Backend {
     Pg,
@@ -60,20 +89,59 @@ impl Backend {
     }
 }
 
-pub fn set_pool(db_url: &str) {
-    let pool = AsyncDieselConnectionManager::<AsyncMysqlConnection>::new(db_url);
-    let conn = Pool::builder(pool).build().unwrap();
-    let pool = POOL.get_or_init(|| Mutex::new(None));
-    *pool.lock().unwrap() = Some(conn);
+pub fn set_pool(backend: &Backend, db_url: &str) {
+    let pool = match backend {
+        Backend::Mysql => {
+            let manager = AsyncDieselConnectionManager::<AsyncMysqlConnection>::new(db_url);
+            DbPool::Mysql(Pool::builder(manager).build().unwrap())
+        }
+        Backend::Pg => {
+            let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(db_url);
+            DbPool::Pg(Pool::builder(manager).build().unwrap())
+        }
+        Backend::Sqlite => {
+            let manager =
+                AsyncDieselConnectionManager::<SyncConnectionWrapper<SqliteConnection>>::new(
+                    db_url,
+                );
+            DbPool::Sqlite(Pool::builder(manager).build().unwrap())
+        }
+    };
+    let cell = POOL.get_or_init(|| Mutex::new(None));
+    *cell.lock().unwrap() = Some(pool);
 }
 
-pub fn get_pool() -> Option<Pool<AsyncMysqlConnection>> {
+pub fn get_pool() -> Option<DbPool> {
     if let Some(mutex) = POOL.get() {
         let pool = mutex.lock().unwrap();
         pool.clone()
     } else {
         None
     }
+}
+
+// Runs `$body` (an async block using `$conn`) against whichever backend
+// `$pool` (a DbPool) actually holds. `$body` must be pure Diesel DSL with no
+// backend-specific syntax — that's what makes running the identical code
+// against three different connection types sound rather than three separately
+// hand-verified implementations.
+macro_rules! with_conn {
+    ($pool:expr, |$conn:ident| $body:expr) => {
+        match $pool {
+            DbPool::Mysql(p) => {
+                let mut $conn = p.get().await?;
+                $body
+            }
+            DbPool::Pg(p) => {
+                let mut $conn = p.get().await?;
+                $body
+            }
+            DbPool::Sqlite(p) => {
+                let mut $conn = p.get().await?;
+                $body
+            }
+        }
+    };
 }
 
 pub async fn create_database(database_url: &str) -> Result<(), crate::errors::Error> {
@@ -93,7 +161,13 @@ pub async fn create_database(database_url: &str) -> Result<(), crate::errors::Er
                     .execute(&mut conn)
                     .await?;
             }
-            return Ok(());
+
+            set_pool(&Backend::Pg, database_url);
+            if let Some(pool) = get_pool() {
+                run_migrations(&pool, POSTGRES_MIGRATIONS).await?;
+            } else {
+                return Err(crate::errors::Error::GetPool);
+            }
         }
         Backend::Sqlite => {
             let path = path_from_sqlite_url(database_url)?;
@@ -106,7 +180,13 @@ pub async fn create_database(database_url: &str) -> Result<(), crate::errors::Er
                         url: database_url.to_owned(),
                     })?;
             }
-            return Ok(());
+
+            set_pool(&Backend::Sqlite, database_url);
+            if let Some(pool) = get_pool() {
+                run_migrations(&pool, SQLITE_MIGRATIONS).await?;
+            } else {
+                return Err(crate::errors::Error::GetPool);
+            }
         }
         Backend::Mysql => {
             if AsyncMysqlConnection::establish(database_url).await.is_err() {
@@ -131,20 +211,34 @@ pub async fn create_database(database_url: &str) -> Result<(), crate::errors::Er
                 }
             }
 
-            set_pool(database_url);
+            set_pool(&Backend::Mysql, database_url);
             if let Some(pool) = get_pool() {
-                let conn = pool.get().await?;
-                let mut harness = AsyncMigrationHarness::new(conn);
-                if let Err(err) = harness.run_pending_migrations(MIGRATIONS) {
-                    tracing::error!("Unable to run migrations: {}", err);
-                    return Err(crate::errors::Error::Migration(err));
-                }
+                run_migrations(&pool, MYSQL_MIGRATIONS).await?;
             } else {
                 return Err(crate::errors::Error::GetPool);
             }
         }
     }
     Ok(())
+}
+
+// AsyncMigrationHarness::new() takes conn by value, not &mut, so the `mut`
+// with_conn! always binds is unused here (but is needed by every other
+// with_conn! call site in this file, which do run &mut queries) — allowed
+// rather than special-casing the shared macro for this one caller.
+#[allow(unused_mut)]
+async fn run_migrations(
+    pool: &DbPool,
+    migrations: EmbeddedMigrations,
+) -> Result<(), crate::errors::Error> {
+    with_conn!(pool.clone(), |conn| {
+        let mut harness = AsyncMigrationHarness::new(conn);
+        if let Err(err) = harness.run_pending_migrations(migrations) {
+            tracing::error!("Unable to run migrations: {}", err);
+            return Err(crate::errors::Error::Migration(err));
+        }
+        Ok(())
+    })
 }
 
 fn change_database_of_url(
@@ -202,24 +296,25 @@ pub async fn create_user(username: String, password: String, email: String) -> R
         .hash_password(password.as_bytes(), &salt)?
         .to_string();
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        let now = select(diesel::dsl::now)
-            .get_result::<NaiveDateTime>(&mut conn)
-            .await?;
+        with_conn!(pool, |conn| {
+            let now = select(diesel::dsl::now)
+                .get_result::<NaiveDateTime>(&mut conn)
+                .await?;
 
-        let new_user = NewUser {
-            username,
-            password: password_hash,
-            email,
-            created_at: now,
-            modified_at: now,
-        };
+            let new_user = NewUser {
+                username,
+                password: password_hash,
+                email,
+                created_at: now,
+                modified_at: now,
+            };
 
-        diesel::insert_into(users::table)
-            .values(&new_user)
-            .execute(&mut conn)
-            .await?;
-        Ok(())
+            diesel::insert_into(users::table)
+                .values(&new_user)
+                .execute(&mut conn)
+                .await?;
+            Ok(())
+        })
     } else {
         Err(crate::errors::Error::GetPool)
     }
@@ -232,45 +327,46 @@ pub async fn register_update_server(
     list_plugin: Vec<String>,
 ) -> Result<(), Error> {
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        let now = select(diesel::dsl::now)
-            .get_result::<NaiveDateTime>(&mut conn)
-            .await?;
+        with_conn!(pool, |conn| {
+            let now = select(diesel::dsl::now)
+                .get_result::<NaiveDateTime>(&mut conn)
+                .await?;
 
-        let json_platforms = serde_json::to_string(&platforms)?;
-        let json_plugins = serde_json::to_string(&list_plugin)?;
-        let repo = NewRepository {
-            name: repository.clone(),
-            created_at: now,
-            platforms: json_platforms,
-            plugins: json_plugins,
-        };
+            let json_platforms = serde_json::to_string(&platforms)?;
+            let json_plugins = serde_json::to_string(&list_plugin)?;
+            let repo = NewRepository {
+                name: repository.clone(),
+                created_at: now,
+                platforms: json_platforms,
+                plugins: json_plugins,
+            };
 
-        diesel::insert_into(repositories::table)
-            .values(&repo)
-            .execute(&mut conn)
-            .await?;
+            diesel::insert_into(repositories::table)
+                .values(&repo)
+                .execute(&mut conn)
+                .await?;
 
-        match users::table
-            .filter(users::dsl::username.eq(username))
-            .select(User::as_select())
-            .first(&mut conn)
-            .await
-        {
-            Ok(val) => {
-                let users_repos = UsersRepositories {
-                    user_id: val.id,
-                    repository_name: repository,
-                    permission: Permission::Write,
-                };
-                diesel::insert_into(users_repositories::table)
-                    .values(&users_repos)
-                    .execute(&mut conn)
-                    .await?;
-                Ok(())
+            match users::table
+                .filter(users::dsl::username.eq(username))
+                .select(User::as_select())
+                .first(&mut conn)
+                .await
+            {
+                Ok(val) => {
+                    let users_repos = UsersRepositories {
+                        user_id: val.id,
+                        repository_name: repository,
+                        permission: Permission::Write,
+                    };
+                    diesel::insert_into(users_repositories::table)
+                        .values(&users_repos)
+                        .execute(&mut conn)
+                        .await?;
+                    Ok(())
+                }
+                Err(err) => Err(crate::errors::Error::Query(err)),
             }
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
+        })
     } else {
         Err(crate::errors::Error::GetPool)
     }
@@ -278,36 +374,37 @@ pub async fn register_update_server(
 
 pub async fn list_update_server_by_user(username: String) -> Result<Vec<String>, Error> {
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match users::table
-            .filter(users::dsl::username.eq(username.clone()))
-            .select(User::as_select())
-            .first(&mut conn)
-            .await
-            .optional()
-        {
-            Ok(Some(val)) => {
-                match users_repositories::table
-                    .filter(users_repositories::dsl::user_id.eq(val.id))
-                    .select(UsersRepositories::as_select())
-                    .load(&mut conn)
-                    .await
-                    .optional()
-                {
-                    Ok(Some(list_repo)) => {
-                        let mut user_repo: Vec<String> = Vec::new();
-                        for repo in list_repo {
-                            user_repo.push(repo.repository_name);
+        with_conn!(pool, |conn| {
+            match users::table
+                .filter(users::dsl::username.eq(username.clone()))
+                .select(User::as_select())
+                .first(&mut conn)
+                .await
+                .optional()
+            {
+                Ok(Some(val)) => {
+                    match users_repositories::table
+                        .filter(users_repositories::dsl::user_id.eq(val.id))
+                        .select(UsersRepositories::as_select())
+                        .load(&mut conn)
+                        .await
+                        .optional()
+                    {
+                        Ok(Some(list_repo)) => {
+                            let mut user_repo: Vec<String> = Vec::new();
+                            for repo in list_repo {
+                                user_repo.push(repo.repository_name);
+                            }
+                            Ok(user_repo)
                         }
-                        Ok(user_repo)
+                        Ok(None) => Ok(Vec::new()),
+                        Err(err) => Err(crate::errors::Error::Query(err)),
                     }
-                    Ok(None) => Ok(Vec::new()),
-                    Err(err) => Err(crate::errors::Error::Query(err)),
                 }
+                Ok(None) => Err(crate::errors::Error::UserNotFound),
+                Err(err) => Err(crate::errors::Error::Query(err)),
             }
-            Ok(None) => Err(crate::errors::Error::UserNotFound),
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
+        })
     } else {
         Err(crate::errors::Error::GetPool)
     }
@@ -315,27 +412,28 @@ pub async fn list_update_server_by_user(username: String) -> Result<Vec<String>,
 
 pub async fn join_update_server(username: String, repository: String) -> Result<(), Error> {
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match users::table
-            .filter(users::dsl::username.eq(username))
-            .select(User::as_select())
-            .first(&mut conn)
-            .await
-        {
-            Ok(val) => {
-                let users_repos = UsersRepositories {
-                    user_id: val.id,
-                    repository_name: repository,
-                    permission: Permission::Pending,
-                };
-                diesel::insert_into(users_repositories::table)
-                    .values(&users_repos)
-                    .execute(&mut conn)
-                    .await?;
-                Ok(())
+        with_conn!(pool, |conn| {
+            match users::table
+                .filter(users::dsl::username.eq(username))
+                .select(User::as_select())
+                .first(&mut conn)
+                .await
+            {
+                Ok(val) => {
+                    let users_repos = UsersRepositories {
+                        user_id: val.id,
+                        repository_name: repository,
+                        permission: Permission::Pending,
+                    };
+                    diesel::insert_into(users_repositories::table)
+                        .values(&users_repos)
+                        .execute(&mut conn)
+                        .await?;
+                    Ok(())
+                }
+                Err(err) => Err(crate::errors::Error::Query(err)),
             }
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
+        })
     } else {
         Err(crate::errors::Error::GetPool)
     }
@@ -343,18 +441,19 @@ pub async fn join_update_server(username: String, repository: String) -> Result<
 
 pub async fn delete_repo(path: String) -> Result<(), Error> {
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        diesel::delete(repositories::table.filter(repositories::dsl::name.eq(path.clone())))
+        with_conn!(pool, |conn| {
+            diesel::delete(repositories::table.filter(repositories::dsl::name.eq(path.clone())))
+                .execute(&mut conn)
+                .await?;
+
+            diesel::delete(
+                users_repositories::table.filter(users_repositories::dsl::repository_name.eq(path)),
+            )
             .execute(&mut conn)
             .await?;
 
-        diesel::delete(
-            users_repositories::table.filter(users_repositories::dsl::repository_name.eq(path)),
-        )
-        .execute(&mut conn)
-        .await?;
-
-        Ok(())
+            Ok(())
+        })
     } else {
         Err(crate::errors::Error::GetPool)
     }
@@ -362,24 +461,257 @@ pub async fn delete_repo(path: String) -> Result<(), Error> {
 
 pub async fn login(username_or_email: String, password: String) -> Result<LucleUser, Error> {
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match users::table
-            .filter(users::dsl::username.eq(username_or_email.clone()))
-            .select(User::as_select())
-            .first(&mut conn)
-            .await
-            .optional()
-        {
-            Ok(Some(val)) => {
-                match users_repositories::table
-                    .filter(users_repositories::dsl::user_id.eq(val.id))
-                    .select(UsersRepositories::as_select())
-                    .load(&mut conn)
-                    .await
-                    .optional()
-                {
-                    Ok(Some(list_repo)) => {
-                        let mut user_repo: Vec<UpdateServer> = Vec::new();
+        with_conn!(pool, |conn| {
+            match users::table
+                .filter(users::dsl::username.eq(username_or_email.clone()))
+                .select(User::as_select())
+                .first(&mut conn)
+                .await
+                .optional()
+            {
+                Ok(Some(val)) => {
+                    match users_repositories::table
+                        .filter(users_repositories::dsl::user_id.eq(val.id))
+                        .select(UsersRepositories::as_select())
+                        .load(&mut conn)
+                        .await
+                        .optional()
+                    {
+                        Ok(Some(list_repo)) => {
+                            let mut user_repo: Vec<UpdateServer> = Vec::new();
+                            let mut repo_platforms: Vec<i32> = Vec::new();
+                            let mut list_plugins: Vec<String> = Vec::new();
+
+                            let mut new_repo = UpdateServer {
+                                path: "".to_string(),
+                                username: "".to_string(),
+                                platforms: Vec::new(),
+                                plugins: Vec::new(),
+                            };
+                            for repo in list_repo {
+                                match repositories::table
+                                    .filter(
+                                        repositories::dsl::name.eq(repo.repository_name.clone()),
+                                    )
+                                    .select(Repository::as_select())
+                                    .load(&mut conn)
+                                    .await
+                                    .optional()
+                                {
+                                    Ok(Some(repo)) => {
+                                        for r in &repo {
+                                            let parsed_platforms: Value =
+                                                serde_json::from_str(&r.platforms)?;
+                                            let parsed_plugins: Value =
+                                                serde_json::from_str(&r.plugins)?;
+                                            if let Some(list_plug) = parsed_plugins.as_array() {
+                                                for list in list_plug {
+                                                    if let Some(p) = list.as_str() {
+                                                        list_plugins.push(p.into());
+                                                    }
+                                                }
+                                            }
+                                            if let Some(list_platforms) =
+                                                parsed_platforms.as_array()
+                                            {
+                                                for platform in list_platforms {
+                                                    if let Some(plat) = platform.as_str() {
+                                                        match plat {
+                                                            "Win64" => repo_platforms
+                                                                .push(Platforms::Win64.into()),
+                                                            "Macosx8664" => repo_platforms
+                                                                .push(Platforms::MacosX8664.into()),
+                                                            "Macosarm64" => repo_platforms
+                                                                .push(Platforms::MacosArm64.into()),
+                                                            "Linux" => repo_platforms
+                                                                .push(Platforms::Linux.into()),
+                                                            _ => {}
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            new_repo = UpdateServer {
+                                                path: r.name.clone(),
+                                                username: val.username.clone(),
+                                                platforms: repo_platforms.clone(),
+                                                plugins: list_plugins.clone(),
+                                            };
+                                            repo_platforms.clear();
+                                        }
+                                    }
+                                    Ok(None) => {}
+                                    Err(err) => {
+                                        return Err(crate::errors::Error::Query(err));
+                                    }
+                                }
+                                user_repo.push(new_repo.clone());
+                            }
+                            login_user(val.username, val.password, password, val.email, user_repo)
+                        }
+                        Ok(None) => {
+                            login_user(val.username, val.password, password, val.email, Vec::new())
+                        }
+                        Err(err) => Err(crate::errors::Error::Query(err)),
+                    }
+                }
+                Ok(None) => {
+                    match users::table
+                        .filter(users::dsl::email.eq(username_or_email.clone()))
+                        .select(User::as_select())
+                        .first(&mut conn)
+                        .await
+                        .optional()
+                    {
+                        Ok(Some(val)) => {
+                            match users_repositories::table
+                                .filter(users_repositories::dsl::user_id.eq(val.id))
+                                .select(UsersRepositories::as_select())
+                                .load(&mut conn)
+                                .await
+                                .optional()
+                            {
+                                Ok(Some(list_repo)) => {
+                                    let mut user_repo: Vec<UpdateServer> = Vec::new();
+                                    let mut repo_platforms: Vec<i32> = Vec::new();
+                                    let mut list_plugins: Vec<String> = Vec::new();
+
+                                    for repo in list_repo {
+                                        match repositories::table
+                                            .filter(
+                                                repositories::dsl::name
+                                                    .eq(repo.repository_name.clone()),
+                                            )
+                                            .select(Repository::as_select())
+                                            .load(&mut conn)
+                                            .await
+                                            .optional()
+                                        {
+                                            Ok(Some(repo)) => {
+                                                for r in &repo {
+                                                    match r.platforms.as_str() {
+                                                        "win64" => repo_platforms
+                                                            .push(Platforms::Win64.into()),
+                                                        "macos_x86_64" => repo_platforms
+                                                            .push(Platforms::MacosX8664.into()),
+                                                        "macos_arm64" => repo_platforms
+                                                            .push(Platforms::MacosArm64.into()),
+                                                        "linux" => repo_platforms
+                                                            .push(Platforms::Linux.into()),
+                                                        _ => {}
+                                                    }
+                                                    let parsed_plugins: Value =
+                                                        serde_json::from_str(&r.plugins)?;
+                                                    if let Some(list_plug) =
+                                                        parsed_plugins.as_array()
+                                                    {
+                                                        for list in list_plug {
+                                                            if let Some(p) = list.as_str() {
+                                                                list_plugins.push(p.into());
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            Ok(None) => {}
+                                            Err(err) => {
+                                                return Err(crate::errors::Error::Query(err))
+                                            }
+                                        }
+                                        let new_repo = UpdateServer {
+                                            path: repo.repository_name,
+                                            username: val.username.clone(),
+                                            platforms: repo_platforms.clone(),
+                                            plugins: list_plugins.clone(),
+                                        };
+                                        user_repo.push(new_repo);
+                                    }
+                                    login_user(
+                                        val.username,
+                                        val.password,
+                                        password,
+                                        val.email,
+                                        user_repo,
+                                    )
+                                }
+                                Ok(None) => login_user(
+                                    val.username,
+                                    val.password,
+                                    password,
+                                    val.email,
+                                    Vec::new(),
+                                ),
+                                Err(err) => Err(crate::errors::Error::Query(err)),
+                            }
+                        }
+                        Ok(None) => Err(crate::errors::Error::UserNotFound),
+                        Err(err) => Err(crate::errors::Error::Query(err)),
+                    }
+                }
+                Err(err) => Err(crate::errors::Error::Query(err)),
+            }
+        })
+    } else {
+        Err(crate::errors::Error::GetPool)
+    }
+}
+
+pub async fn is_table_created() -> Result<(), Error> {
+    if let Some(pool) = get_pool() {
+        with_conn!(pool, |conn| {
+            match users::table.count().get_result::<i64>(&mut conn).await {
+                Ok(user_count) => {
+                    if user_count > 0 {
+                        Ok(())
+                    } else {
+                        Err(crate::errors::Error::UserNotCreated)
+                    }
+                }
+                Err(err) => Err(crate::errors::Error::Query(err)),
+            }
+        })
+    } else {
+        Err(crate::errors::Error::GetPool)
+    }
+}
+
+pub async fn is_default_user_created() -> Result<(), Error> {
+    if let Some(pool) = get_pool() {
+        with_conn!(pool, |conn| {
+            match users::table.count().get_result::<i64>(&mut conn).await {
+                Ok(user_count) => {
+                    if user_count > 0 {
+                        Ok(())
+                    } else {
+                        Err(crate::errors::Error::UserNotCreated)
+                    }
+                }
+                Err(err) => Err(crate::errors::Error::Query(err)),
+            }
+        })
+    } else {
+        Err(crate::errors::Error::GetPool)
+    }
+}
+
+pub async fn reset_password(email: String) -> Result<(), Error> {
+    if let Some(pool) = get_pool() {
+        with_conn!(pool, |conn| {
+            match users::table
+                .filter(users::dsl::email.eq(email.clone()))
+                .select(User::as_select())
+                .first(&mut conn)
+                .await
+                .optional()
+            {
+                Ok(Some(val)) => {
+                    let mut user_repo: Vec<UpdateServer> = Vec::new();
+                    if let Some(list_repo) = users_repositories::table
+                        .filter(users_repositories::dsl::user_id.eq(val.id))
+                        .select(UsersRepositories::as_select())
+                        .load(&mut conn)
+                        .await
+                        .optional()?
+                    {
                         let mut repo_platforms: Vec<i32> = Vec::new();
                         let mut list_plugins: Vec<String> = Vec::new();
 
@@ -443,279 +775,58 @@ pub async fn login(username_or_email: String, password: String) -> Result<LucleU
                             }
                             user_repo.push(new_repo.clone());
                         }
-                        login_user(val.username, val.password, password, val.email, user_repo)
                     }
-                    Ok(None) => {
-                        login_user(val.username, val.password, password, val.email, Vec::new())
+                    let repo_string: Vec<String> = user_repo
+                        .into_iter()
+                        .map(|update_server| update_server.path)
+                        .collect();
+                    let token = utils::generate_jwt(val.username, val.email.clone(), repo_string)?;
+                    if diesel::update(users::table.filter(users::dsl::email.eq(val.email.clone())))
+                        .set(users::dsl::reset_token.eq(token))
+                        .execute(&mut conn)
+                        .await
+                        .is_ok()
+                    {
+                        utils::send_mail(&email, &val.email, "test", "hi");
+                        return Ok(());
                     }
-                    Err(err) => Err(crate::errors::Error::Query(err)),
                 }
+                Ok(None) => return Err(crate::errors::Error::EmailNotFound),
+                Err(err) => return Err(crate::errors::Error::Query(err)),
             }
-            Ok(None) => {
-                match users::table
-                    .filter(users::dsl::email.eq(username_or_email.clone()))
-                    .select(User::as_select())
-                    .first(&mut conn)
-                    .await
-                    .optional()
-                {
-                    Ok(Some(val)) => {
-                        match users_repositories::table
-                            .filter(users_repositories::dsl::user_id.eq(val.id))
-                            .select(UsersRepositories::as_select())
-                            .load(&mut conn)
-                            .await
-                            .optional()
-                        {
-                            Ok(Some(list_repo)) => {
-                                let mut user_repo: Vec<UpdateServer> = Vec::new();
-                                let mut repo_platforms: Vec<i32> = Vec::new();
-                                let mut list_plugins: Vec<String> = Vec::new();
-
-                                for repo in list_repo {
-                                    match repositories::table
-                                        .filter(
-                                            repositories::dsl::name
-                                                .eq(repo.repository_name.clone()),
-                                        )
-                                        .select(Repository::as_select())
-                                        .load(&mut conn)
-                                        .await
-                                        .optional()
-                                    {
-                                        Ok(Some(repo)) => {
-                                            for r in &repo {
-                                                match r.platforms.as_str() {
-                                                    "win64" => {
-                                                        repo_platforms.push(Platforms::Win64.into())
-                                                    }
-                                                    "macos_x86_64" => repo_platforms
-                                                        .push(Platforms::MacosX8664.into()),
-                                                    "macos_arm64" => repo_platforms
-                                                        .push(Platforms::MacosArm64.into()),
-                                                    "linux" => {
-                                                        repo_platforms.push(Platforms::Linux.into())
-                                                    }
-                                                    _ => {}
-                                                }
-                                                let parsed_plugins: Value =
-                                                    serde_json::from_str(&r.plugins)?;
-                                                if let Some(list_plug) = parsed_plugins.as_array() {
-                                                    for list in list_plug {
-                                                        if let Some(p) = list.as_str() {
-                                                            list_plugins.push(p.into());
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        Ok(None) => {}
-                                        Err(err) => return Err(crate::errors::Error::Query(err)),
-                                    }
-                                    let new_repo = UpdateServer {
-                                        path: repo.repository_name,
-                                        username: val.username.clone(),
-                                        platforms: repo_platforms.clone(),
-                                        plugins: list_plugins.clone(),
-                                    };
-                                    user_repo.push(new_repo);
-                                }
-                                login_user(
-                                    val.username,
-                                    val.password,
-                                    password,
-                                    val.email,
-                                    user_repo,
-                                )
-                            }
-                            Ok(None) => login_user(
-                                val.username,
-                                val.password,
-                                password,
-                                val.email,
-                                Vec::new(),
-                            ),
-                            Err(err) => Err(crate::errors::Error::Query(err)),
-                        }
-                    }
-                    Ok(None) => Err(crate::errors::Error::UserNotFound),
-                    Err(err) => Err(crate::errors::Error::Query(err)),
-                }
-            }
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
+            Ok(())
+        })
     } else {
-        Err(crate::errors::Error::GetPool)
+        Ok(())
     }
-}
-
-pub async fn is_table_created() -> Result<(), Error> {
-    if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match users::table.count().get_result::<i64>(&mut conn).await {
-            Ok(user_count) => {
-                if user_count > 0 {
-                    Ok(())
-                } else {
-                    Err(crate::errors::Error::UserNotCreated)
-                }
-            }
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
-    } else {
-        Err(crate::errors::Error::GetPool)
-    }
-}
-
-pub async fn is_default_user_created() -> Result<(), Error> {
-    if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match users::table.count().get_result::<i64>(&mut conn).await {
-            Ok(user_count) => {
-                if user_count > 0 {
-                    Ok(())
-                } else {
-                    Err(crate::errors::Error::UserNotCreated)
-                }
-            }
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
-    } else {
-        Err(crate::errors::Error::GetPool)
-    }
-}
-
-pub async fn reset_password(email: String) -> Result<(), Error> {
-    if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match users::table
-            .filter(users::dsl::email.eq(email.clone()))
-            .select(User::as_select())
-            .first(&mut conn)
-            .await
-            .optional()
-        {
-            Ok(Some(val)) => {
-                let mut user_repo: Vec<UpdateServer> = Vec::new();
-                if let Some(list_repo) = users_repositories::table
-                    .filter(users_repositories::dsl::user_id.eq(val.id))
-                    .select(UsersRepositories::as_select())
-                    .load(&mut conn)
-                    .await
-                    .optional()?
-                {
-                    let mut repo_platforms: Vec<i32> = Vec::new();
-                    let mut list_plugins: Vec<String> = Vec::new();
-
-                    let mut new_repo = UpdateServer {
-                        path: "".to_string(),
-                        username: "".to_string(),
-                        platforms: Vec::new(),
-                        plugins: Vec::new(),
-                    };
-                    for repo in list_repo {
-                        match repositories::table
-                            .filter(repositories::dsl::name.eq(repo.repository_name.clone()))
-                            .select(Repository::as_select())
-                            .load(&mut conn)
-                            .await
-                            .optional()
-                        {
-                            Ok(Some(repo)) => {
-                                for r in &repo {
-                                    let parsed_platforms: Value =
-                                        serde_json::from_str(&r.platforms)?;
-                                    let parsed_plugins: Value = serde_json::from_str(&r.plugins)?;
-                                    if let Some(list_plug) = parsed_plugins.as_array() {
-                                        for list in list_plug {
-                                            if let Some(p) = list.as_str() {
-                                                list_plugins.push(p.into());
-                                            }
-                                        }
-                                    }
-                                    if let Some(list_platforms) = parsed_platforms.as_array() {
-                                        for platform in list_platforms {
-                                            if let Some(plat) = platform.as_str() {
-                                                match plat {
-                                                    "Win64" => {
-                                                        repo_platforms.push(Platforms::Win64.into())
-                                                    }
-                                                    "Macosx8664" => repo_platforms
-                                                        .push(Platforms::MacosX8664.into()),
-                                                    "Macosarm64" => repo_platforms
-                                                        .push(Platforms::MacosArm64.into()),
-                                                    "Linux" => {
-                                                        repo_platforms.push(Platforms::Linux.into())
-                                                    }
-                                                    _ => {}
-                                                }
-                                            }
-                                        }
-                                    }
-                                    new_repo = UpdateServer {
-                                        path: r.name.clone(),
-                                        username: val.username.clone(),
-                                        platforms: repo_platforms.clone(),
-                                        plugins: list_plugins.clone(),
-                                    };
-                                    repo_platforms.clear();
-                                }
-                            }
-                            Ok(None) => {}
-                            Err(err) => {
-                                return Err(crate::errors::Error::Query(err));
-                            }
-                        }
-                        user_repo.push(new_repo.clone());
-                    }
-                }
-                let repo_string: Vec<String> = user_repo
-                    .into_iter()
-                    .map(|update_server| update_server.path)
-                    .collect();
-                let token = utils::generate_jwt(val.username, val.email.clone(), repo_string)?;
-                if diesel::update(users::table.filter(users::dsl::email.eq(val.email.clone())))
-                    .set(users::dsl::reset_token.eq(token))
-                    .execute(&mut conn)
-                    .await
-                    .is_ok()
-                {
-                    utils::send_mail(&email, &val.email, "test", "hi");
-                    return Ok(());
-                }
-            }
-            Ok(None) => return Err(crate::errors::Error::EmailNotFound),
-            Err(err) => return Err(crate::errors::Error::Query(err)),
-        }
-    }
-    Ok(())
 }
 
 pub async fn list_plugin_by_repository(repository_name: String) -> Result<Vec<String>, Error> {
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match repositories::table
-            .filter(repositories::dsl::name.eq(repository_name))
-            .select(Repository::as_select())
-            .first(&mut conn)
-            .await
-            .optional()
-        {
-            Ok(Some(repo)) => {
-                let mut plugins_list: Vec<String> = Vec::new();
-                let parsed_plugins: Value = serde_json::from_str(&repo.plugins)?;
-                if let Some(list_plug) = parsed_plugins.as_array() {
-                    for list in list_plug {
-                        if let Some(p) = list.as_str() {
-                            plugins_list.push(p.into());
+        with_conn!(pool, |conn| {
+            match repositories::table
+                .filter(repositories::dsl::name.eq(repository_name))
+                .select(Repository::as_select())
+                .first(&mut conn)
+                .await
+                .optional()
+            {
+                Ok(Some(repo)) => {
+                    let mut plugins_list: Vec<String> = Vec::new();
+                    let parsed_plugins: Value = serde_json::from_str(&repo.plugins)?;
+                    if let Some(list_plug) = parsed_plugins.as_array() {
+                        for list in list_plug {
+                            if let Some(p) = list.as_str() {
+                                plugins_list.push(p.into());
+                            }
                         }
                     }
+                    Ok(plugins_list)
                 }
-                Ok(plugins_list)
+                Ok(None) => Ok(Vec::new()),
+                Err(err) => Err(crate::errors::Error::Query(err)),
             }
-            Ok(None) => Ok(Vec::new()),
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
+        })
     } else {
         Err(crate::errors::Error::GetPool)
     }
@@ -725,24 +836,25 @@ pub async fn get_plugin_version(
     plugins_name: Vec<String>,
 ) -> Result<HashMap<String, String>, Error> {
     if let Some(pool) = get_pool() {
-        let mut conn = pool.get().await?;
-        match plugins::table
-            .filter(plugins::dsl::name.eq_any(plugins_name))
-            .select(Plugins::as_select())
-            .load(&mut conn)
-            .await
-            .optional()
-        {
-            Ok(Some(plugins)) => {
-                let plugin_with_version: HashMap<String, String> = plugins
-                    .into_iter()
-                    .map(|plug| (plug.name, plug.version))
-                    .collect();
-                Ok(plugin_with_version)
+        with_conn!(pool, |conn| {
+            match plugins::table
+                .filter(plugins::dsl::name.eq_any(plugins_name))
+                .select(Plugins::as_select())
+                .load(&mut conn)
+                .await
+                .optional()
+            {
+                Ok(Some(plugins)) => {
+                    let plugin_with_version: HashMap<String, String> = plugins
+                        .into_iter()
+                        .map(|plug| (plug.name, plug.version))
+                        .collect();
+                    Ok(plugin_with_version)
+                }
+                Ok(None) => Ok(HashMap::new()),
+                Err(err) => Err(crate::errors::Error::Query(err)),
             }
-            Ok(None) => Ok(HashMap::new()),
-            Err(err) => Err(crate::errors::Error::Query(err)),
-        }
+        })
     } else {
         Err(crate::errors::Error::GetPool)
     }
@@ -768,4 +880,52 @@ fn login_user(
         token,
         repositories,
     })
+}
+
+#[cfg(test)]
+mod temp_sqlite_verification {
+    use super::*;
+
+    // SyncConnectionWrapper (SQLite) needs a multi-threaded runtime for its
+    // internal spawn_blocking calls — the default #[tokio::test] runtime is
+    // single-threaded and panics here with "can call blocking only when
+    // running on the multi-threaded runtime". main.rs's #[tokio::main] is
+    // multi-threaded by default (no flavor override), so production is fine;
+    // this only affects this test's own runtime choice.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sqlite_end_to_end() {
+        let path = std::env::temp_dir().join(format!("lucle_verify_{}.db", std::process::id()));
+        let path_str = path.to_str().unwrap().to_string();
+        let _ = std::fs::remove_file(&path);
+
+        create_database(&path_str).await.expect("create_database");
+
+        create_user("alice".into(), "hunter2".into(), "alice@example.com".into())
+            .await
+            .expect("create_user");
+
+        register_update_server("alice".into(), "myrepo".into(), vec![], vec![])
+            .await
+            .expect("register_update_server (permission = Write)");
+
+        let repos = list_update_server_by_user("alice".into())
+            .await
+            .expect("list_update_server_by_user");
+        assert_eq!(repos, vec!["myrepo".to_string()]);
+
+        is_table_created().await.expect("is_table_created");
+
+        let plugins = get_plugin_version(vec!["nonexistent".into()])
+            .await
+            .expect("get_plugin_version");
+        assert!(plugins.is_empty());
+
+        join_update_server("alice".into(), "otherrepo".into())
+            .await
+            .expect("join_update_server (permission = Pending)");
+
+        delete_repo("myrepo".into()).await.expect("delete_repo");
+
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use axum::Router;
-use diesel_async::{pooled_connection::deadpool::Pool, AsyncMysqlConnection};
 use dotenvy::dotenv;
 use std::net::SocketAddr;
 use tower_http::cors::{Any, CorsLayer};
@@ -16,9 +15,15 @@ mod rpc;
 pub mod schema;
 mod utils;
 
+// rpc::rpc_api() takes this but doesn't currently read it (its param is
+// `_db`) — the real source of truth for "is a database available" is
+// diesel::get_pool(), populated below. Kept as a marker rather than removed
+// outright since rpc_api()'s signature already expects it.
 pub enum DbType {
-    Mysql(Pool<AsyncMysqlConnection>),
-    Surrealdb(),
+    Mysql,
+    Postgresql,
+    Sqlite,
+    Surrealdb,
     NoDatabase,
 }
 
@@ -61,15 +66,45 @@ async fn main() {
                 let name = utils::get_config_key("database", "name").unwrap();
                 let user = utils::get_config_key("database", "user").unwrap();
                 let password = utils::get_config_key("database", "password").unwrap();
-                diesel::set_pool(&(format!("mysql://{user}:{password}@{url}:{port}/{name}")));
-                if let Some(pool) = diesel::get_pool() {
-                    DbType::Mysql(pool)
+                diesel::set_pool(
+                    &diesel::Backend::Mysql,
+                    &format!("mysql://{user}:{password}@{url}:{port}/{name}"),
+                );
+                if diesel::get_pool().is_some() {
+                    DbType::Mysql
                 } else {
                     tracing::error!("Unable to get pool connection");
                     DbType::NoDatabase
                 }
             }
-            "surrealdb" => DbType::Surrealdb(),
+            "postgresql" => {
+                let url = utils::get_config_key("database", "url").unwrap();
+                let port = utils::get_config_key("database", "port").unwrap();
+                let name = utils::get_config_key("database", "name").unwrap();
+                let user = utils::get_config_key("database", "user").unwrap();
+                let password = utils::get_config_key("database", "password").unwrap();
+                diesel::set_pool(
+                    &diesel::Backend::Pg,
+                    &format!("postgres://{user}:{password}@{url}:{port}/{name}"),
+                );
+                if diesel::get_pool().is_some() {
+                    DbType::Postgresql
+                } else {
+                    tracing::error!("Unable to get pool connection");
+                    DbType::NoDatabase
+                }
+            }
+            "sqlite" => {
+                let path = utils::get_config_key("database", "path").unwrap();
+                diesel::set_pool(&diesel::Backend::Sqlite, &path);
+                if diesel::get_pool().is_some() {
+                    DbType::Sqlite
+                } else {
+                    tracing::error!("Unable to get pool connection");
+                    DbType::NoDatabase
+                }
+            }
+            "surrealdb" => DbType::Surrealdb,
             _ => DbType::NoDatabase,
         };
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 
 #[derive(Debug, Queryable, Selectable)]
 #[diesel(table_name = users)]
-#[diesel(check_for_backend(diesel::mysql::Mysql))]
+#[diesel(check_for_backend(diesel::mysql::Mysql, diesel::sqlite::Sqlite, diesel::pg::Pg))]
 pub struct User {
     pub id: i32,
     pub username: String,
@@ -36,7 +36,7 @@ pub struct NewUser {
 
 #[derive(Insertable, Selectable, Queryable, Debug, PartialEq)]
 #[diesel(table_name = repositories)]
-#[diesel(check_for_backend(diesel::mysql::Mysql))]
+#[diesel(check_for_backend(diesel::mysql::Mysql, diesel::sqlite::Sqlite, diesel::pg::Pg))]
 pub struct Repository {
     pub id: i32,
     pub name: String,
@@ -56,7 +56,7 @@ pub struct NewRepository {
 
 #[derive(Insertable, Selectable, Queryable, Debug, PartialEq)]
 #[diesel(table_name = users_repositories)]
-#[diesel(check_for_backend(diesel::mysql::Mysql))]
+#[diesel(check_for_backend(diesel::mysql::Mysql, diesel::sqlite::Sqlite, diesel::pg::Pg))]
 pub struct UsersRepositories {
     pub user_id: i32,
     pub repository_name: String,
@@ -93,9 +93,65 @@ impl FromSql<UsersRepositoriesPermissionEnum, diesel::mysql::Mysql> for Permissi
     }
 }
 
+// SQLite has no native enum type — UsersRepositoriesPermissionEnum maps to
+// Text there (see schema.rs's sqlite_type annotation), so this stores the
+// same lowercase strings as the MySQL native enum does.
+impl ToSql<UsersRepositoriesPermissionEnum, diesel::sqlite::Sqlite> for Permission {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, diesel::sqlite::Sqlite>) -> serialize::Result {
+        let value = match *self {
+            Permission::Read => "read",
+            Permission::Write => "write",
+            Permission::Pending => "pending",
+        };
+        out.set_value(value);
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<UsersRepositoriesPermissionEnum, diesel::sqlite::Sqlite> for Permission {
+    fn from_sql(value: diesel::sqlite::SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+        match <String as FromSql<diesel::sql_types::Text, diesel::sqlite::Sqlite>>::from_sql(value)?
+            .as_str()
+        {
+            "read" => Ok(Permission::Read),
+            "write" => Ok(Permission::Write),
+            "pending" => Ok(Permission::Pending),
+            _ => Err("Unrecognized enum variant".into()),
+        }
+    }
+}
+
+// PostgreSQL path, same Text-backed approach as SQLite above. NOT verified
+// against a live PostgreSQL server in this environment (no server available
+// to test against) — compiles and mirrors the SQLite impl exactly, but
+// please test this against a real Postgres instance before relying on it.
+impl ToSql<UsersRepositoriesPermissionEnum, diesel::pg::Pg> for Permission {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, diesel::pg::Pg>) -> serialize::Result {
+        let value = match *self {
+            Permission::Read => "read",
+            Permission::Write => "write",
+            Permission::Pending => "pending",
+        };
+        <str as ToSql<diesel::sql_types::Text, diesel::pg::Pg>>::to_sql(value, out)
+    }
+}
+
+impl FromSql<UsersRepositoriesPermissionEnum, diesel::pg::Pg> for Permission {
+    fn from_sql(value: diesel::pg::PgValue<'_>) -> deserialize::Result<Self> {
+        match <String as FromSql<diesel::sql_types::Text, diesel::pg::Pg>>::from_sql(value)?
+            .as_str()
+        {
+            "read" => Ok(Permission::Read),
+            "write" => Ok(Permission::Write),
+            "pending" => Ok(Permission::Pending),
+            _ => Err("Unrecognized enum variant".into()),
+        }
+    }
+}
+
 #[derive(Insertable, Selectable, Queryable, Debug, PartialEq)]
 #[diesel(table_name = plugins)]
-#[diesel(check_for_backend(diesel::mysql::Mysql))]
+#[diesel(check_for_backend(diesel::mysql::Mysql, diesel::sqlite::Sqlite, diesel::pg::Pg))]
 pub struct Plugins {
     pub id: i32,
     pub name: String,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -66,13 +66,13 @@ impl Lucle for LucleApi {
         let db_name = inner.clone().db_name.unwrap_or("lucle".to_string());
         match DatabaseType::try_from(db_type) {
             Ok(DatabaseType::Sqlite) => {
-                // create_database() creates the file, but there's no connection
-                // pool implementation for SQLite yet (POOL is hardcoded to
-                // AsyncMysqlConnection) — every request after this would fail
-                // with "Cannot get Pool" while the client believes install
-                // succeeded (#140). Fail loudly instead, same as Surrealdb.
-                tracing::error!("Unable to create Sqlite database, it's currently not supported");
-                return Err(Status::internal("Database not supported".to_string()));
+                let db_path = "lucle.db";
+                if let Err(err) = diesel::create_database(db_path).await {
+                    tracing::error!("Unable to create database : {}", err);
+                    return Err(Status::internal(err.to_string()));
+                }
+                utils::set_config_key("database", "type", "sqlite");
+                utils::set_config_key("database", "path", db_path);
             }
             Ok(DatabaseType::Mysql) => {
                 if let Some(db_connection) = inner.db_connection {
@@ -91,7 +91,6 @@ impl Lucle for LucleApi {
                         tracing::error!("Unable to create database : {}", err);
                         return Err(Status::internal(err.to_string()));
                     }
-                    diesel::set_pool(db_url);
                     utils::set_config_key("database", "type", "mysql");
                     utils::set_config_key("database", "url", &db_connection.hostname);
                     utils::set_config_key("database", "port", &db_connection.port.to_string());
@@ -105,15 +104,37 @@ impl Lucle for LucleApi {
                 }
             }
             Ok(DatabaseType::Postgresql) => {
-                // Same problem as Sqlite above (no pool implementation for
-                // AsyncPgConnection), plus this call was passing the literal
-                // string "postgres://" instead of a URL built from
-                // inner.db_connection, so database creation itself was never
-                // going to succeed either. Fail loudly instead of pretending.
-                tracing::error!(
-                    "Unable to create PostgreSQL database, it's currently not supported"
-                );
-                return Err(Status::internal("Database not supported".to_string()));
+                // NOTE: this path compiles and mirrors the Mysql branch, but
+                // is not verified against a live PostgreSQL server in this
+                // environment (see the PR description). Please test before
+                // relying on it.
+                if let Some(db_connection) = inner.db_connection {
+                    let db_url = &("postgres://".to_owned()
+                        + &db_connection.username
+                        + ":"
+                        + &db_connection.password
+                        + "@"
+                        + &db_connection.hostname
+                        + ":"
+                        + &db_connection.port.to_string()
+                        + "/"
+                        + &db_name);
+
+                    if let Err(err) = diesel::create_database(db_url).await {
+                        tracing::error!("Unable to create database : {}", err);
+                        return Err(Status::internal(err.to_string()));
+                    }
+                    utils::set_config_key("database", "type", "postgresql");
+                    utils::set_config_key("database", "url", &db_connection.hostname);
+                    utils::set_config_key("database", "port", &db_connection.port.to_string());
+                    utils::set_config_key("database", "name", &db_name);
+                    utils::set_config_key("database", "user", &db_connection.username);
+                    utils::set_config_key("database", "password", &db_connection.password);
+                } else {
+                    return Err(Status::invalid_argument(
+                        "Missing PostgreSQL connection information",
+                    ));
+                }
             }
             Ok(DatabaseType::Surrealdb) => {
                 tracing::error!(

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -66,10 +66,13 @@ impl Lucle for LucleApi {
         let db_name = inner.clone().db_name.unwrap_or("lucle".to_string());
         match DatabaseType::try_from(db_type) {
             Ok(DatabaseType::Sqlite) => {
-                if let Err(err) = diesel::create_database("lucle.db").await {
-                    tracing::error!("Unable to create database : {}", err);
-                    return Err(Status::internal(err.to_string()));
-                }
+                // create_database() creates the file, but there's no connection
+                // pool implementation for SQLite yet (POOL is hardcoded to
+                // AsyncMysqlConnection) — every request after this would fail
+                // with "Cannot get Pool" while the client believes install
+                // succeeded (#140). Fail loudly instead, same as Surrealdb.
+                tracing::error!("Unable to create Sqlite database, it's currently not supported");
+                return Err(Status::internal("Database not supported".to_string()));
             }
             Ok(DatabaseType::Mysql) => {
                 if let Some(db_connection) = inner.db_connection {
@@ -102,10 +105,15 @@ impl Lucle for LucleApi {
                 }
             }
             Ok(DatabaseType::Postgresql) => {
-                if let Err(err) = diesel::create_database("postgres://").await {
-                    tracing::error!("Unable to create database : {}", err);
-                    return Err(Status::internal(err.to_string()));
-                }
+                // Same problem as Sqlite above (no pool implementation for
+                // AsyncPgConnection), plus this call was passing the literal
+                // string "postgres://" instead of a URL built from
+                // inner.db_connection, so database creation itself was never
+                // going to succeed either. Fail loudly instead of pretending.
+                tracing::error!(
+                    "Unable to create PostgreSQL database, it's currently not supported"
+                );
+                return Err(Status::internal("Database not supported".to_string()));
             }
             Ok(DatabaseType::Surrealdb) => {
                 tracing::error!(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2,7 +2,11 @@
 
 pub mod sql_types {
     #[derive(diesel::sql_types::SqlType)]
-    #[diesel(mysql_type(name = "Enum"))]
+    #[diesel(
+        mysql_type(name = "Enum"),
+        sqlite_type(name = "Text"),
+        postgres_type(name = "Text")
+    )]
     pub struct UsersRepositoriesPermissionEnum;
 }
 


### PR DESCRIPTION
Fixes #140. Updated per your comment below — implements real multi-backend support instead of just refusing SQLite/PostgreSQL at install.

## Original bug

\`POOL\` (\`src/diesel.rs\`) was a global \`OnceLock<Mutex<Pool<AsyncMysqlConnection>>>\` — hardcoded to MySQL. \`create_db\`'s Sqlite/Postgresql branches created the database but never called \`set_pool\`/persisted config, so a user picking either left a server that believed it was installed but could never reach the database — "Cannot get Pool" on every request, forever.

## What this now does

Since diesel_async's `MultiConnection` trait isn't released yet, added an interim `DbPool` enum (Mysql/Pg/Sqlite) + a `with_conn!` macro that runs the *same* Diesel query code against whichever concrete connection type the pool holds — one query implementation, monomorphized three ways, not three hand-written paths.

Also found along the way: the existing migrations are MySQL-only SQL (`AUTO_INCREMENT`, native `ENUM(...)`) — even with a working pool, SQLite/PostgreSQL would've failed at schema creation. Added `migrations_sqlite/` and `migrations_postgres/` with portable equivalents. Both include `'pending'` as a valid permission (the original MySQL `ENUM("read","write")` is missing it, even though `Permission::Pending` is a real, used Rust variant — a latent bug on MySQL too, left untouched since changing that enum has its own risk for existing deployments).

`create_db` now wires Sqlite the same way Mysql already did; PostgreSQL likewise (and its `create_database("postgres://")` literal-string bug is fixed to build a real URL). `main.rs`'s startup path restores all three from config on restart.

## Verification

- `cargo check` / `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`: clean.
- **SQLite**: verified twice — raw migration SQL run against a real local sqlite3 file via the CLI, *and* a new `#[tokio::test]` (`sqlite_end_to_end`, this repo's first test) exercising the full Rust path — create_database → create_user → register_update_server → list_update_server_by_user → is_table_created → get_plugin_version → join_update_server → delete_repo — against a real temp SQLite file. Passes.
- **PostgreSQL: not runtime-verified.** No Postgres server available here (local install is a stopped Windows service I don't have permission to start; no Postgres CI service either). Code compiles and mirrors the MySQL/SQLite paths exactly, but please test against a real instance before relying on it. Happy to help wire up a docker-compose Postgres CI job if that'd be useful going forward.
- **MySQL**: unchanged behavior, just routed through the same `DbPool` machinery.