### PR TITLE
fix: repair the vite-plus version spec so `vp install` resolves

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,6 @@
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^7.0.0",
-    "vite-plus": "^0.2. 9"
+    "vite-plus": "^0.2.9"
   }
 }


### PR DESCRIPTION
`web/package.json` has a stray space in the version spec:

```json
"vite-plus": "^0.2. 9"
```

so pnpm can't resolve it and the `setup-vp` step dies before the frontend job compiles anything:

```
[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for vite-plus@^0.2. 9
  while fetching it from https://registry.npmjs.org/
The latest release of vite-plus is "0.2.9".
```

`main`'s own Build check is currently red on this (`205e701`, `c5b681a`), and so is every PR branched off it — including my #142.

One character removed. Verified `pnpm install` resolves `vite-plus 0.2.9` after this.